### PR TITLE
Add training script with Lightning

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,0 +1,58 @@
+# Example training configuration for Kandinsky 3.0 using PyTorch Lightning
+
+model:
+  unet:
+    model_channels: 384
+    num_channels: 4
+    init_channels: 192
+    time_embed_dim: 1536
+    context_dim: 4096
+    groups: 32
+    head_dim: 64
+    expansion_ratio: 4
+    compression_ratio: 2
+    dim_mult: [1, 2, 4, 8]
+    num_blocks: [3, 3, 3, 3]
+    add_cross_attention: [false, true, true, true]
+    add_self_attention: [false, true, true, true]
+  movq:
+    params:
+      double_z: false
+      z_channels: 4
+      resolution: 256
+      in_channels: 3
+      out_ch: 3
+      ch: 256
+      ch_mult: [1, 2, 2, 4]
+      num_res_blocks: 2
+      attn_resolutions: [32]
+      dropout: 0.0
+  text_encoder:
+    model_path: google/flan-ul2
+    low_cpu_mem_usage: true
+    dtype: float32
+  diffusion:
+    schedule_params:
+      schedule_name: cosine
+      timesteps: 1000
+    diffusion_params:
+      percentile: null
+
+data:
+  dataset_name: path/to/dataset # HuggingFace dataset path or name
+  image_field: image
+  text_field: text
+  split: train
+  image_size: 256
+  tokens_length: 128
+  batch_size: 4
+  num_workers: 4
+
+optimizer:
+  lr: 1e-4
+  weight_decay: 1e-2
+
+trainer:
+  max_epochs: 1
+  accelerator: auto
+  precision: 32

--- a/train.py
+++ b/train.py
@@ -1,0 +1,120 @@
+import os
+from argparse import ArgumentParser
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from torchvision import transforms
+from PIL import Image
+
+import pytorch_lightning as pl
+from datasets import load_dataset
+from omegaconf import OmegaConf
+
+from kandinsky3.model.unet import UNet
+from kandinsky3.movq import MoVQ
+from kandinsky3.condition_encoders import T5TextConditionEncoder
+from kandinsky3.condition_processors import T5TextConditionProcessor
+from kandinsky3.model.diffusion import get_named_beta_schedule, BaseDiffusion
+
+
+class TextImageDataset(torch.utils.data.Dataset):
+    def __init__(self, name, split, image_field, text_field, image_size):
+        self.ds = load_dataset(name, split=split)
+        self.image_field = image_field
+        self.text_field = text_field
+        self.transform = transforms.Compose([
+            transforms.Resize(image_size, interpolation=transforms.InterpolationMode.BICUBIC),
+            transforms.CenterCrop(image_size),
+            transforms.ToTensor(),
+            transforms.Normalize(0.5, 0.5)
+        ])
+
+    def __len__(self):
+        return len(self.ds)
+
+    def __getitem__(self, idx):
+        sample = self.ds[idx]
+        image = sample[self.image_field]
+        if not isinstance(image, Image.Image):
+            image = Image.open(image).convert("RGB")
+        image = self.transform(image)
+        caption = sample[self.text_field]
+        return {"image": image, "text": caption}
+
+
+class KandinskyLightningModule(pl.LightningModule):
+    def __init__(self, conf):
+        super().__init__()
+        self.save_hyperparameters(OmegaConf.to_container(conf, resolve=True))
+        self.conf = conf
+
+        self.unet = UNet(**conf.model.unet)
+        self.movq = MoVQ(conf.model.movq.params)
+        self.t5_processor = T5TextConditionProcessor(conf.data.tokens_length, conf.model.text_encoder.model_path)
+        self.t5_encoder = T5TextConditionEncoder(
+            conf.model.text_encoder.model_path,
+            conf.model.unet.context_dim,
+            low_cpu_mem_usage=conf.model.text_encoder.low_cpu_mem_usage,
+            dtype=getattr(torch, conf.model.text_encoder.dtype)
+        )
+
+        betas = get_named_beta_schedule(**conf.model.diffusion.schedule_params)
+        self.diffusion = BaseDiffusion(betas, **conf.model.diffusion.diffusion_params)
+
+    def configure_optimizers(self):
+        opt = torch.optim.AdamW(self.parameters(), lr=self.conf.optimizer.lr, weight_decay=self.conf.optimizer.weight_decay)
+        return opt
+
+    def training_step(self, batch, batch_idx):
+        images = batch["image"]
+        texts = batch["text"]
+
+        encoded = [self.t5_processor.encode(t)[0] for t in texts]
+        input_ids = torch.stack([e['input_ids'] for e in encoded]).to(self.device)
+        attention_mask = torch.stack([e['attention_mask'] for e in encoded]).to(self.device)
+        condition_model_input = {
+            'input_ids': input_ids,
+            'attention_mask': attention_mask
+        }
+        with torch.no_grad():
+            context, context_mask = self.t5_encoder(condition_model_input)
+            latents = self.movq.encode(images)
+
+        t = torch.randint(0, self.diffusion.num_timesteps, (images.size(0),), device=self.device)
+        noise = torch.randn_like(latents)
+        noisy_latents = self.diffusion.q_sample(latents, t, noise)
+        pred_noise = self.unet(noisy_latents, t * self.diffusion.time_scale, context, context_mask.bool())
+
+        loss = F.mse_loss(pred_noise, noise)
+        self.log("loss", loss)
+        return loss
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    args = parser.parse_args()
+
+    conf = OmegaConf.load(args.config)
+
+    dm = TextImageDataset(
+        conf.data.dataset_name,
+        conf.data.split,
+        conf.data.image_field,
+        conf.data.text_field,
+        conf.data.image_size,
+    )
+    dataloader = DataLoader(dm, batch_size=conf.data.batch_size, num_workers=conf.data.num_workers, shuffle=True, drop_last=True)
+
+    model = KandinskyLightningModule(conf)
+    trainer = pl.Trainer(
+        max_epochs=conf.trainer.max_epochs,
+        accelerator=conf.trainer.accelerator,
+        precision=conf.trainer.precision,
+    )
+    trainer.fit(model, dataloader)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add PyTorch Lightning script for training Kandinsky-3.0
- provide sample YAML config for easy customization

## Testing
- `python -m py_compile train.py`
- `pip install torch torchvision` *(fails: Package(s) not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851debb48888327ac9ac288666bbab5