### PR TITLE
Add UNet width scaling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ pip install -r requirements.txt;
 ```
 The exact dependencies is got using `pip freeze` and can be found in `exact_requirements.txt`
 
+## Training
+
+The training script `train.py` relies on a YAML configuration. To scale the U-Net
+and train larger models, adjust the `channel_multiplier` value inside your config
+(for example `configs/train.yaml`). Setting this value above `1.0` increases the
+number of channels across the network, resulting in a larger parameter count.
+
 ## How to use:
 
 Check our jupyter notebooks with examples in `./examples` folder

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -7,6 +7,8 @@ model:
     init_channels: 192
     time_embed_dim: 1536
     context_dim: 4096
+    # multiplier applied to channel dimensions of the UNet
+    channel_multiplier: 1.0
     groups: 32
     head_dim: 64
     expansion_ratio: 4

--- a/train.py
+++ b/train.py
@@ -49,12 +49,20 @@ class KandinskyLightningModule(pl.LightningModule):
         self.save_hyperparameters(OmegaConf.to_container(conf, resolve=True))
         self.conf = conf
 
-        self.unet = UNet(**conf.model.unet)
+        unet_conf = conf.model.unet
+        scale = unet_conf.get('channel_multiplier', 1.0)
+        if scale != 1.0:
+            unet_conf = unet_conf.copy()
+            unet_conf.model_channels = int(unet_conf.model_channels * scale)
+            unet_conf.init_channels = int(unet_conf.init_channels * scale)
+            unet_conf.time_embed_dim = int(unet_conf.time_embed_dim * scale)
+            unet_conf.context_dim = int(unet_conf.context_dim * scale)
+        self.unet = UNet(**unet_conf)
         self.movq = MoVQ(conf.model.movq.params)
         self.t5_processor = T5TextConditionProcessor(conf.data.tokens_length, conf.model.text_encoder.model_path)
         self.t5_encoder = T5TextConditionEncoder(
             conf.model.text_encoder.model_path,
-            conf.model.unet.context_dim,
+            unet_conf.context_dim,
             low_cpu_mem_usage=conf.model.text_encoder.low_cpu_mem_usage,
             dtype=getattr(torch, conf.model.text_encoder.dtype)
         )


### PR DESCRIPTION
## Summary
- support scaling of UNet channel dimensions for training larger models
- expose `channel_multiplier` in example training config
- document how to change this parameter

## Testing
- `pytest -q`
- `python -m py_compile train.py kandinsky3/model/unet.py`

------
https://chatgpt.com/codex/tasks/task_e_6851e21e67008327a66841c6bbb74650